### PR TITLE
Fix OpenLayers map naming conflict

### DIFF
--- a/frontend/src/components/MapViewport.jsx
+++ b/frontend/src/components/MapViewport.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef } from 'react';
-import Map from 'ol/Map';
+import OlMap from 'ol/Map';
 import View from 'ol/View';
 import { fromLonLat, toLonLat } from 'ol/proj';
 import TileLayer from 'ol/layer/Tile';
@@ -84,7 +84,7 @@ export default function MapViewport() {
 
   useEffect(() => {
     if (!mapElementRef.current || mapRef.current) return;
-    const map = new Map({
+    const map = new OlMap({
       target: mapElementRef.current,
       view: baseView,
       layers: [],


### PR DESCRIPTION
## Summary
- rename the OpenLayers map import to avoid colliding with the built-in Map
- ensure overlay layer refs use the native Map implementation

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68d7f1933718832ea6abdd089553f58b