### PR TITLE
Add annotation editor for map annotations

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { format, parseISO } from 'date-fns';
 import MapViewport from './components/MapViewport.jsx';
+import AnnotationEditor from './components/AnnotationEditor.jsx';
 import ComparisonMaps from './components/ComparisonMaps.jsx';
 import AnnotationPanel from './components/AnnotationPanel.jsx';
 import DeepSpaceSearch from './components/DeepSpaceSearch.jsx';
@@ -299,6 +300,7 @@ export default function App() {
 
       <main className="app-main">
         <MapViewport />
+        <AnnotationEditor />
         <div className="map-toolbar">
           {selectedDataset && (
             <div className="badge">

--- a/frontend/src/components/AnnotationEditor.jsx
+++ b/frontend/src/components/AnnotationEditor.jsx
@@ -1,0 +1,89 @@
+import useStore from '../state/useStore.js';
+
+export default function AnnotationEditor() {
+  const {
+    annotationEditor,
+    updateAnnotationEditor,
+    closeAnnotationEditor,
+    addAnnotation
+  } = useStore((state) => ({
+    annotationEditor: state.annotationEditor,
+    updateAnnotationEditor: state.updateAnnotationEditor,
+    closeAnnotationEditor: state.closeAnnotationEditor,
+    addAnnotation: state.addAnnotation
+  }));
+
+  if (!annotationEditor.isOpen) {
+    return null;
+  }
+
+  const handleChange = (key) => (event) => {
+    updateAnnotationEditor({ [key]: event.target.value });
+  };
+
+  const handleCancel = () => {
+    closeAnnotationEditor();
+  };
+
+  const handleSubmit = (event) => {
+    event.preventDefault();
+
+    if (!annotationEditor.geometry) {
+      closeAnnotationEditor();
+      return;
+    }
+
+    const name = annotationEditor.name?.trim();
+    const notes = annotationEditor.notes ?? '';
+
+    addAnnotation({
+      type: 'Feature',
+      geometry: annotationEditor.geometry,
+      id: annotationEditor.id ?? `anno-${Date.now()}`,
+      properties: {
+        datasetId: annotationEditor.datasetId,
+        createdAt: annotationEditor.createdAt ?? new Date().toISOString(),
+        name: name && name.length > 0 ? name : 'Untitled feature',
+        notes
+      }
+    });
+
+    closeAnnotationEditor();
+  };
+
+  return (
+    <div className="annotation-editor" role="dialog" aria-modal="true" aria-labelledby="annotation-editor-title">
+      <form onSubmit={handleSubmit} className="annotation-editor__form">
+        <h4 id="annotation-editor-title">Annotation details</h4>
+        <label>
+          <span>Title</span>
+          <input
+            type="text"
+            value={annotationEditor.name}
+            onChange={handleChange('name')}
+            placeholder="New annotation"
+            required
+            maxLength={120}
+          />
+        </label>
+        <label>
+          <span>Notes</span>
+          <textarea
+            rows={4}
+            value={annotationEditor.notes}
+            onChange={handleChange('notes')}
+            placeholder="Add contextual notes"
+          />
+        </label>
+        <div className="annotation-editor__actions">
+          <button type="button" onClick={handleCancel} className="annotation-editor__button annotation-editor__button--secondary">
+            Cancel
+          </button>
+          <button type="submit" className="annotation-editor__button">
+            Save annotation
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/components/MapViewport.jsx
+++ b/frontend/src/components/MapViewport.jsx
@@ -60,10 +60,10 @@ export default function MapViewport() {
     selectedDate,
     annotations,
     annotationMode,
-    addAnnotation,
     setAnnotationMode,
     setAnnotations,
-    setMapState
+    setMapState,
+    openAnnotationEditor
   } = useStore((state) => ({
     datasets: state.datasets,
     selectedDatasetId: state.selectedDatasetId,
@@ -71,10 +71,10 @@ export default function MapViewport() {
     selectedDate: state.selectedDate,
     annotations: state.annotations,
     annotationMode: state.annotationMode,
-    addAnnotation: state.addAnnotation,
     setAnnotationMode: state.setAnnotationMode,
     setAnnotations: state.setAnnotations,
-    setMapState: state.setMapState
+    setMapState: state.setMapState,
+    openAnnotationEditor: state.openAnnotationEditor
   }));
 
   const selectedDataset = useMemo(
@@ -234,20 +234,21 @@ export default function MapViewport() {
       });
 
       const id = `anno-${Date.now()}`;
-      const name = window.prompt('Annotation title', 'New annotation');
-      const notes = window.prompt('Notes', '');
-      const annotation = {
-        type: 'Feature',
-        geometry,
+      const createdAt = new Date().toISOString();
+
+      const source = annotationsLayerRef.current?.getSource();
+      if (source) {
+        source.removeFeature(feature);
+      }
+
+      openAnnotationEditor({
         id,
-        properties: {
-          datasetId: selectedDatasetId,
-          createdAt: new Date().toISOString(),
-          name: name || 'Untitled feature',
-          notes: notes || ''
-        }
-      };
-      addAnnotation(annotation);
+        geometry,
+        datasetId: selectedDatasetId,
+        name: 'New annotation',
+        notes: '',
+        createdAt
+      });
       setAnnotationMode('idle');
     });
 
@@ -257,7 +258,7 @@ export default function MapViewport() {
     return () => {
       map.removeInteraction(draw);
     };
-  }, [annotationMode, selectedDatasetId, addAnnotation, setAnnotationMode]);
+  }, [annotationMode, selectedDatasetId, setAnnotationMode, openAnnotationEditor]);
 
   return <div ref={mapElementRef} className="map-container" role="presentation" />;
 }

--- a/frontend/src/state/useStore.js
+++ b/frontend/src/state/useStore.js
@@ -3,6 +3,16 @@ import { create } from 'zustand';
 
 const defaultDate = formatISO(new Date(), { representation: 'date' });
 
+const createEmptyAnnotationEditor = () => ({
+  isOpen: false,
+  id: null,
+  datasetId: null,
+  geometry: null,
+  name: '',
+  notes: '',
+  createdAt: null
+});
+
 const useStore = create((set, get) => ({
   datasets: [],
   datasetStatus: 'idle',
@@ -19,6 +29,7 @@ const useStore = create((set, get) => ({
   annotations: [],
   annotationMode: 'idle',
   annotationStatus: 'idle',
+  annotationEditor: createEmptyAnnotationEditor(),
   mapExtent: null,
   mapCenter: [0, 0],
   mastResults: [],
@@ -66,6 +77,11 @@ const useStore = create((set, get) => ({
   clearAnnotations: () => set({ annotations: [] }),
   setAnnotationMode: (mode) => set({ annotationMode: mode }),
   setAnnotationStatus: (status) => set({ annotationStatus: status }),
+  openAnnotationEditor: (payload) =>
+    set({ annotationEditor: { ...createEmptyAnnotationEditor(), ...payload, isOpen: true } }),
+  updateAnnotationEditor: (updates) =>
+    set({ annotationEditor: { ...get().annotationEditor, ...updates } }),
+  closeAnnotationEditor: () => set({ annotationEditor: createEmptyAnnotationEditor() }),
   setMapState: ({ extent, center }) =>
     set({ mapExtent: extent ?? get().mapExtent, mapCenter: center ?? get().mapCenter }),
   setMastStatus: (status) => set({ mastStatus: status }),

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -198,6 +198,80 @@ button:disabled {
   overflow-y: auto;
 }
 
+.annotation-editor {
+  position: absolute;
+  bottom: 1.5rem;
+  left: 1.5rem;
+  width: min(320px, calc(100% - 3rem));
+  background: rgba(7, 13, 28, 0.92);
+  border: 1px solid rgba(136, 192, 255, 0.25);
+  border-radius: 0.85rem;
+  box-shadow: 0 16px 32px rgba(0, 0, 0, 0.4);
+  padding: 1.1rem;
+  z-index: 40;
+  backdrop-filter: blur(10px);
+}
+
+.annotation-editor__form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.annotation-editor__form h4 {
+  margin: 0;
+  font-size: 0.95rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.annotation-editor__form label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-size: 0.75rem;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.annotation-editor__form input,
+.annotation-editor__form textarea {
+  width: 100%;
+  font-family: inherit;
+  font-size: 0.85rem;
+  padding: 0.5rem 0.65rem;
+  border-radius: 0.65rem;
+  border: 1px solid rgba(136, 192, 255, 0.35);
+  background: rgba(9, 16, 30, 0.8);
+  color: #f4f7ff;
+  resize: vertical;
+}
+
+.annotation-editor__form textarea {
+  min-height: 96px;
+}
+
+.annotation-editor__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}
+
+.annotation-editor__button {
+  border-radius: 0.65rem;
+  padding: 0.45rem 0.9rem;
+  border: 1px solid rgba(136, 192, 255, 0.45);
+  background: rgba(136, 192, 255, 0.22);
+  color: #f4f7ff;
+  font-size: 0.8rem;
+}
+
+.annotation-editor__button--secondary {
+  background: transparent;
+  border-color: rgba(255, 255, 255, 0.25);
+  color: rgba(255, 255, 255, 0.75);
+}
+
 .annotation-item {
   background: rgba(16, 28, 53, 0.8);
   padding: 0.5rem 0.6rem;


### PR DESCRIPTION
## Summary
- replace prompt-driven annotation capture with a dedicated editor overlay
- keep annotation editor state and draft metadata in the zustand store
- add styling and componentry for editing and saving annotations asynchronously

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d7f5c9ce68832ead8c64029617aa14