### PR TITLE
Cache GIBS available-date responses

### DIFF
--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -100,6 +100,9 @@ const DATASETS = [
   }
 ];
 
+const AVAILABLE_DATES_TTL_MS = 5 * 60 * 1000;
+const availableDatesCache = new Map();
+
 async function ensureAnnotationsFile() {
   try {
     await fs.access(ANNOTATIONS_PATH);
@@ -160,9 +163,13 @@ app.get('/api/gibs/available-dates', async (req, res) => {
     return { iso, testUrl };
   });
 
-  const checks = descriptors.map(({ testUrl }) =>
-    fetch(testUrl, { method: 'HEAD' })
-  );
+  const cacheKey = `${layer}:${days}`;
+  const cachedEntry = availableDatesCache.get(cacheKey);
+  if (cachedEntry && Date.now() - cachedEntry.timestamp < AVAILABLE_DATES_TTL_MS) {
+    return res.json({ layer, dates: cachedEntry.dates });
+  }
+
+  const checks = descriptors.map(({ testUrl }) => fetch(testUrl, { method: 'HEAD' }));
 
   const responses = await Promise.allSettled(checks);
 
@@ -178,6 +185,8 @@ app.get('/api/gibs/available-dates', async (req, res) => {
       console.warn('Date availability check failed', result.reason?.message || result.reason);
     }
   });
+
+  availableDatesCache.set(cacheKey, { timestamp: Date.now(), dates: results });
 
   res.json({ layer, dates: results });
 });


### PR DESCRIPTION
## Summary
- add an in-memory cache for `/api/gibs/available-dates` responses so repeat lookups reuse NASA results
- return cached data within a five-minute TTL to avoid redundant HEAD probes while keeping data fresh

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68d7f5063ab4832e9697b535a00cdefd