### PR TITLE
Add mission board to landing page

### DIFF
--- a/frontend/src/components/MissionBoard.jsx
+++ b/frontend/src/components/MissionBoard.jsx
@@ -1,0 +1,140 @@
+import { useEffect, useMemo, useState } from 'react';
+import PropTypes from 'prop-types';
+import { celestialBodies } from '../data/celestialBodies.js';
+import { getVisitedBodies } from '../utils/progress.js';
+
+const FEATURED_MISSIONS = celestialBodies.slice(0, 5);
+
+function deriveInitialMission(visitedSet) {
+  const nextTarget = FEATURED_MISSIONS.find((body) => !visitedSet.has(body.id));
+  return nextTarget ? nextTarget.id : FEATURED_MISSIONS[0]?.id ?? '';
+}
+
+function makeBadgeStyle(color) {
+  return {
+    background: `radial-gradient(circle at 30% 30%, ${color}, rgba(8, 13, 28, 0.9))`,
+    boxShadow: '0 0 0 1px rgba(255, 255, 255, 0.05), 0 16px 34px rgba(4, 8, 20, 0.55)'
+  };
+}
+
+export default function MissionBoard({ visitedBodies, onMissionComplete }) {
+  const [localVisited, setLocalVisited] = useState(() => visitedBodies ?? getVisitedBodies());
+  const [activeMission, setActiveMission] = useState(() => deriveInitialMission(localVisited));
+
+  useEffect(() => {
+    if (!visitedBodies) return;
+    setLocalVisited(visitedBodies);
+  }, [visitedBodies]);
+
+  useEffect(() => {
+    setActiveMission((previous) => {
+      if (previous && FEATURED_MISSIONS.some((body) => body.id === previous)) {
+        return previous;
+      }
+      return deriveInitialMission(localVisited);
+    });
+  }, [localVisited]);
+
+  const missionDetails = useMemo(() => FEATURED_MISSIONS, []);
+
+  function handleMissionSelect(event) {
+    setActiveMission(event.target.value);
+  }
+
+  function handleCompleteMission(missionId) {
+    if (localVisited.has(missionId)) return;
+    if (onMissionComplete) {
+      const result = onMissionComplete(missionId);
+      if (result instanceof Set) {
+        setLocalVisited(result);
+        return;
+      }
+    }
+    setLocalVisited((prev) => {
+      const next = new Set(prev);
+      next.add(missionId);
+      return next;
+    });
+  }
+
+  return (
+    <div className="mission-board" aria-label="Mission control board">
+      <div className="mission-board-console">
+        <label htmlFor="active-mission-select" className="mission-board-label">
+          Active mission
+        </label>
+        <div className="mission-board-select">
+          <select
+            id="active-mission-select"
+            value={activeMission}
+            onChange={handleMissionSelect}
+            aria-describedby="mission-status"
+          >
+            {missionDetails.map((body) => (
+              <option key={body.id} value={body.id}>
+                {body.name}
+              </option>
+            ))}
+          </select>
+          <span id="mission-status" className="mission-board-status">
+            {localVisited.has(activeMission) ? 'Mission logged' : 'Awaiting deployment'}
+          </span>
+        </div>
+      </div>
+      <div className="mission-card-grid">
+        {missionDetails.map((body) => {
+          const isActive = activeMission === body.id;
+          const isCompleted = localVisited.has(body.id);
+          const missionTag = (body.datasetCategory ?? body.id).toUpperCase();
+          const badgeInitials = body.name
+            .split(' ')
+            .map((part) => part[0])
+            .join('')
+            .slice(0, 3)
+            .toUpperCase();
+
+          return (
+            <article
+              key={body.id}
+              className={`mission-card${isActive ? ' active' : ''}${isCompleted ? ' completed' : ''}`}
+            >
+              <div className="mission-card-badge" style={makeBadgeStyle(body.color)} aria-hidden="true">
+                <span className="mission-card-initials">{badgeInitials}</span>
+              </div>
+              <div className="mission-card-body">
+                <header>
+                  <h3>{body.name}</h3>
+                  <span className="mission-card-status">
+                    {isCompleted ? 'Mission Complete' : isActive ? 'Standing By' : 'Queued'}
+                  </span>
+                </header>
+                <p>{body.highlights?.[0] ?? body.description}</p>
+                <footer className="mission-card-actions">
+                  <span className="mission-card-tag">Mission Tag: {missionTag}</span>
+                  <button
+                    type="button"
+                    onClick={() => handleCompleteMission(body.id)}
+                    disabled={isCompleted}
+                    className="mission-card-button"
+                  >
+                    {isCompleted ? 'Logged' : 'Mark Complete'}
+                  </button>
+                </footer>
+              </div>
+            </article>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+MissionBoard.propTypes = {
+  visitedBodies: PropTypes.instanceOf(Set),
+  onMissionComplete: PropTypes.func
+};
+
+MissionBoard.defaultProps = {
+  visitedBodies: undefined,
+  onMissionComplete: undefined
+};

--- a/frontend/src/pages/LandingPage.jsx
+++ b/frontend/src/pages/LandingPage.jsx
@@ -2,7 +2,8 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useSpaceAudio } from '../state/SpaceAudioContext.js';
 import { celestialBodies } from '../data/celestialBodies.js';
-import { getVisitedBodies } from '../utils/progress.js';
+import MissionBoard from '../components/MissionBoard.jsx';
+import { getVisitedBodies, markBodyVisited } from '../utils/progress.js';
 
 function usePrefersReducedMotion() {
   const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
@@ -140,7 +141,11 @@ export default function LandingPage() {
     navigate('/explore');
   }
 
-  const topTargets = celestialBodies.slice(0, 5);
+  function handleMissionComplete(missionId) {
+    const updated = markBodyVisited(missionId);
+    setVisitedBodies(new Set(updated));
+    return updated;
+  }
 
   return (
     <div className="landing-root">
@@ -168,14 +173,7 @@ export default function LandingPage() {
           <p>
             Visited bodies: {progress.visited} / {progress.total} ({Number.isFinite(progress.percentage) ? progress.percentage : 0}% complete)
           </p>
-          <ul>
-            {topTargets.map((body) => (
-              <li key={body.id} className={visitedBodies.has(body.id) ? 'visited' : ''}>
-                <span>{body.name}</span>
-                <span>{visitedBodies.has(body.id) ? '✓ Logged' : 'Awaiting Briefing'}</span>
-              </li>
-            ))}
-          </ul>
+          <MissionBoard visitedBodies={visitedBodies} onMissionComplete={handleMissionComplete} />
         </section>
         <section className="landing-footer">
           <p>

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -294,27 +294,185 @@ button:disabled {
   backdrop-filter: blur(14px);
 }
 
-.landing-progress ul {
-  margin: 1.25rem 0 0;
-  padding: 0;
-  list-style: none;
+.mission-board {
+  margin-top: 1.25rem;
+  border-radius: 1rem;
+  background: linear-gradient(145deg, rgba(10, 16, 32, 0.9), rgba(6, 10, 24, 0.75));
+  border: 1px solid rgba(136, 192, 255, 0.14);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06), 0 20px 40px rgba(3, 6, 18, 0.6);
+  padding: 1rem 1.1rem 1.2rem;
   display: grid;
-  gap: 0.6rem;
+  gap: 1rem;
 }
 
-.landing-progress li {
+.mission-board-console {
+  display: grid;
+  gap: 0.4rem;
+}
+
+.mission-board-label {
+  text-transform: uppercase;
+  font-size: 0.65rem;
+  letter-spacing: 0.18em;
+  color: rgba(197, 214, 255, 0.65);
+}
+
+.mission-board-select {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+  background: rgba(5, 9, 21, 0.72);
+  border: 1px solid rgba(136, 192, 255, 0.18);
+  border-radius: 0.75rem;
+  padding: 0.55rem 0.75rem;
+  box-shadow: inset 0 0 12px rgba(88, 134, 210, 0.12);
+}
+
+.mission-board-select select {
+  background: rgba(10, 15, 30, 0.65);
+  border: 1px solid rgba(136, 192, 255, 0.28);
+  color: #e7edff;
+  padding: 0.45rem 0.75rem;
+  border-radius: 0.65rem;
+  font-size: 0.9rem;
+  font-family: 'Share Tech Mono', 'Fira Code', monospace;
+  letter-spacing: 0.05em;
+  appearance: none;
+  position: relative;
+  box-shadow: 0 4px 14px rgba(10, 20, 40, 0.35);
+}
+
+.mission-board-select select:focus-visible {
+  outline: 2px solid rgba(149, 254, 170, 0.55);
+  outline-offset: 3px;
+}
+
+.mission-board-status {
+  font-size: 0.75rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: rgba(143, 220, 255, 0.75);
+}
+
+.mission-card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+  gap: 0.9rem;
+}
+
+.mission-card {
+  display: grid;
+  grid-template-columns: 70px 1fr;
+  gap: 0.85rem;
+  padding: 0.8rem 0.9rem;
+  border-radius: 1rem;
+  background: rgba(7, 11, 24, 0.78);
+  border: 1px solid rgba(136, 192, 255, 0.16);
+  transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+  box-shadow: 0 8px 24px rgba(4, 8, 20, 0.45);
+}
+
+.mission-card:hover {
+  transform: translateY(-2px);
+  border-color: rgba(149, 254, 170, 0.25);
+  box-shadow: 0 18px 30px rgba(3, 7, 18, 0.55);
+}
+
+.mission-card.active {
+  border-color: rgba(149, 254, 170, 0.35);
+  box-shadow: 0 20px 42px rgba(2, 10, 32, 0.65);
+}
+
+.mission-card.completed {
+  background: linear-gradient(165deg, rgba(10, 16, 32, 0.9), rgba(9, 20, 28, 0.75));
+  border-color: rgba(149, 254, 170, 0.4);
+}
+
+.mission-card-badge {
+  position: relative;
+  border-radius: 0.9rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  min-height: 100%;
+}
+
+.mission-card-initials {
+  font-family: 'Share Tech Mono', 'Fira Code', monospace;
+  font-size: 0.95rem;
+  letter-spacing: 0.2em;
+  color: rgba(8, 12, 22, 0.85);
+  text-transform: uppercase;
+  background: rgba(255, 255, 255, 0.82);
+  padding: 0.2rem 0.35rem;
+  border-radius: 0.4rem;
+}
+
+.mission-card-body {
+  display: grid;
+  gap: 0.55rem;
+}
+
+.mission-card-body header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 0.5rem;
+}
+
+.mission-card-body h3 {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.mission-card-status {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: rgba(181, 220, 255, 0.65);
+}
+
+.mission-card-body p {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(215, 226, 255, 0.78);
+}
+
+.mission-card-actions {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 0.65rem 0.9rem;
-  border-radius: 0.75rem;
-  background: rgba(13, 20, 40, 0.7);
-  border: 1px solid rgba(136, 192, 255, 0.12);
+  gap: 0.75rem;
 }
 
-.landing-progress li.visited {
-  border-color: rgba(149, 254, 170, 0.35);
-  background: rgba(12, 24, 32, 0.85);
+.mission-card-tag {
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(149, 212, 255, 0.72);
+}
+
+.mission-card-button {
+  padding: 0.45rem 0.9rem;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  border-radius: 0.65rem;
+  background: linear-gradient(135deg, rgba(149, 254, 170, 0.85), rgba(94, 201, 255, 0.85));
+  border: none;
+  color: rgba(7, 12, 20, 0.9);
+  font-weight: 600;
+  box-shadow: 0 12px 24px rgba(6, 15, 30, 0.45);
+}
+
+.mission-card-button:disabled {
+  opacity: 0.65;
+  background: rgba(149, 254, 170, 0.35);
+  color: rgba(211, 233, 220, 0.8);
+  cursor: default;
+  box-shadow: none;
 }
 
 .landing-footer {


### PR DESCRIPTION
## Summary
- add a MissionBoard component that surfaces featured missions with badges and completion controls
- embed the new console-style board on the landing page and update mission completion handling
- style the board and dropdown to match the glassmorphism flight deck aesthetic

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d80a99bcdc832e9e07f3f70fa740c8