### PR TITLE
Add navigation console to Solar System experience

### DIFF
--- a/frontend/src/components/NavigationConsole.jsx
+++ b/frontend/src/components/NavigationConsole.jsx
@@ -1,0 +1,207 @@
+import { useEffect, useMemo, useState } from 'react';
+
+const FILTER_DEFINITIONS = [
+  {
+    value: 'all',
+    label: 'All Destinations',
+    predicate: () => true
+  },
+  {
+    value: 'inner-worlds',
+    label: 'Inner Worlds',
+    predicate: (body) =>
+      ['mercury', 'venus', 'earth', 'moon', 'mars'].includes(body.id)
+  },
+  {
+    value: 'outer-giants',
+    label: 'Gas & Ice Giants',
+    predicate: (body) =>
+      ['jupiter', 'saturn', 'uranus', 'neptune'].includes(body.id)
+  },
+  {
+    value: 'stellar',
+    label: 'Stellar Targets',
+    predicate: (body) => body.id === 'sun'
+  }
+];
+
+const VISITED_FILTERS = [
+  { value: 'all', label: 'All' },
+  { value: 'visited', label: 'Visited' },
+  { value: 'unvisited', label: 'Unvisited' }
+];
+
+function computeDailyChallenge(bodies) {
+  if (!bodies.length) return null;
+  const today = new Date().toISOString().slice(0, 10);
+  const hash = today
+    .split('')
+    .reduce((accumulator, char) => accumulator + char.charCodeAt(0), 0);
+  return bodies[hash % bodies.length];
+}
+
+export default function NavigationConsole({
+  bodies = [],
+  selectedBodyId,
+  visitedBodies,
+  onSelectBody,
+  onMarkVisited,
+  onBeginExploration
+}) {
+  const [filterValue, setFilterValue] = useState('all');
+  const [visitFilter, setVisitFilter] = useState('all');
+
+  const visitedSet = useMemo(() => {
+    if (visitedBodies instanceof Set) return visitedBodies;
+    if (Array.isArray(visitedBodies)) return new Set(visitedBodies);
+    return new Set();
+  }, [visitedBodies]);
+
+  const filteredBodies = useMemo(() => {
+    const filterDefinition =
+      FILTER_DEFINITIONS.find((definition) => definition.value === filterValue) || FILTER_DEFINITIONS[0];
+
+    return bodies
+      .filter((body) => filterDefinition.predicate(body))
+      .filter((body) => {
+        if (visitFilter === 'visited') {
+          return visitedSet.has(body.id);
+        }
+        if (visitFilter === 'unvisited') {
+          return !visitedSet.has(body.id);
+        }
+        return true;
+      })
+      .sort((a, b) => a.orbitRadius - b.orbitRadius);
+  }, [bodies, filterValue, visitFilter, visitedSet]);
+
+  const selectedBody = useMemo(
+    () => bodies.find((body) => body.id === selectedBodyId) || null,
+    [bodies, selectedBodyId]
+  );
+
+  useEffect(() => {
+    if (!filteredBodies.length) {
+      return;
+    }
+    const isSelectedInFilter = filteredBodies.some((body) => body.id === selectedBodyId);
+    if (!isSelectedInFilter) {
+      onSelectBody(filteredBodies[0].id);
+    }
+  }, [filteredBodies, onSelectBody, selectedBodyId]);
+
+  function handleCycle(step) {
+    if (!filteredBodies.length) return;
+    const currentIndex = filteredBodies.findIndex((body) => body.id === selectedBodyId);
+    const safeIndex = currentIndex === -1 ? 0 : currentIndex;
+    const nextIndex = (safeIndex + step + filteredBodies.length) % filteredBodies.length;
+    onSelectBody(filteredBodies[nextIndex].id);
+  }
+
+  const challengeBody = useMemo(() => computeDailyChallenge(bodies), [bodies]);
+  const challengeCompleted = challengeBody ? visitedSet.has(challengeBody.id) : false;
+
+  return (
+    <section className="navigation-console" aria-label="Navigation Console">
+      <header>
+        <h2>Navigation Console</h2>
+        <p>Filter your flight plan and keep tabs on your exploration streak.</p>
+      </header>
+
+      <label className="console-filter">
+        Destination filter
+        <select value={filterValue} onChange={(event) => setFilterValue(event.target.value)}>
+          {FILTER_DEFINITIONS.map((definition) => (
+            <option key={definition.value} value={definition.value}>
+              {definition.label}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      <div className="console-toggle" role="group" aria-label="Visited filter">
+        {VISITED_FILTERS.map((filterOption) => (
+          <button
+            key={filterOption.value}
+            type="button"
+            className={visitFilter === filterOption.value ? 'active' : ''}
+            onClick={() => setVisitFilter(filterOption.value)}
+          >
+            {filterOption.label}
+          </button>
+        ))}
+      </div>
+
+      <div className="console-active">
+        <div>
+          <h3>Active destination</h3>
+          <p>{selectedBody ? selectedBody.name : 'Select a celestial body'}</p>
+        </div>
+        <div className="console-actions">
+          <button type="button" onClick={() => handleCycle(-1)} disabled={!filteredBodies.length}>
+            ◂ Previous
+          </button>
+          <button type="button" onClick={() => handleCycle(1)} disabled={!filteredBodies.length}>
+            Next ▸
+          </button>
+          <button
+            type="button"
+            className="primary"
+            onClick={() => selectedBody && onBeginExploration(selectedBody.id)}
+            disabled={!selectedBody}
+          >
+            Launch mission
+          </button>
+        </div>
+      </div>
+
+      <div className="console-manifest">
+        <h4>Filtered manifest</h4>
+        {filteredBodies.length ? (
+          <ul>
+            {filteredBodies.map((body) => (
+              <li key={body.id}>
+                <button
+                  type="button"
+                  className={body.id === selectedBodyId ? 'active' : ''}
+                  onClick={() => onSelectBody(body.id)}
+                >
+                  <span>{body.name}</span>
+                  {visitedSet.has(body.id) && <span className="badge">Visited</span>}
+                </button>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="console-empty">No bodies match the current filters.</p>
+        )}
+      </div>
+
+      {challengeBody && (
+        <article className={`console-card ${challengeCompleted ? 'complete' : ''}`}>
+          <header>
+            <h3>Daily Challenge</h3>
+            <span>{challengeCompleted ? 'Complete' : 'Pending'}</span>
+          </header>
+          <p>
+            Plot a course to <strong>{challengeBody.name}</strong> to keep your streak going.
+          </p>
+          <div className="console-card__actions">
+            <button type="button" onClick={() => onSelectBody(challengeBody.id)}>
+              Focus target
+            </button>
+            <button
+              type="button"
+              className="primary"
+              onClick={() =>
+                challengeCompleted ? onBeginExploration(challengeBody.id) : onMarkVisited(challengeBody.id)
+              }
+            >
+              {challengeCompleted ? 'Review mission data' : 'Mark visited'}
+            </button>
+          </div>
+        </article>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/pages/SolarSystemPage.jsx
+++ b/frontend/src/pages/SolarSystemPage.jsx
@@ -1,4 +1,4 @@
-import { Suspense, useEffect, useMemo, useRef, useState } from 'react';
+import { Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Canvas, useFrame, useThree } from '@react-three/fiber';
 import { Html, OrbitControls, Stars } from '@react-three/drei';
 import * as THREE from 'three';
@@ -6,6 +6,7 @@ import { useNavigate } from 'react-router-dom';
 import { celestialBodies, getBodyById } from '../data/celestialBodies.js';
 import { getVisitedBodies, markBodyVisited } from '../utils/progress.js';
 import { useSpaceAudio } from '../state/SpaceAudioContext.js';
+import NavigationConsole from '../components/NavigationConsole.jsx';
 
 function OrbitRing({ radius }) {
   const points = useMemo(() => {
@@ -26,10 +27,11 @@ function OrbitRing({ radius }) {
   );
 }
 
-function CelestialBody({ body, isSelected, onSelect, onExplore }) {
+function CelestialBody({ body, isSelected, onSelect, onExplore, onPositionUpdate }) {
   const groupRef = useRef();
   const meshRef = useRef();
   const worldPosition = useRef(new THREE.Vector3());
+  const orbitalPosition = useRef(new THREE.Vector3());
 
   useFrame(({ clock }) => {
     const elapsed = clock.getElapsedTime();
@@ -38,6 +40,10 @@ function CelestialBody({ body, isSelected, onSelect, onExplore }) {
     const z = Math.sin(orbitAngle) * body.orbitRadius;
     if (groupRef.current) {
       groupRef.current.position.set(x, 0, z);
+    }
+    orbitalPosition.current.set(x, 0, z);
+    if (onPositionUpdate) {
+      onPositionUpdate(body.id, orbitalPosition.current);
     }
     if (meshRef.current) {
       meshRef.current.rotation.y += body.rotationSpeed;
@@ -112,23 +118,57 @@ export default function SolarSystemPage() {
   });
   const [visitedBodies, setVisitedBodies] = useState(() => getVisitedBodies());
   const { start } = useSpaceAudio();
+  const bodyPositionsRef = useRef(new Map());
 
   useEffect(() => {
     start();
   }, [start]);
 
-  const selectedBody = getBodyById(selectedBodyId);
+  const handlePositionUpdate = useCallback((bodyId, position) => {
+    bodyPositionsRef.current.set(bodyId, [position.x, position.y, position.z]);
+  }, []);
 
-  function handleSelect(body, worldPosition) {
+  const handleConsoleSelect = useCallback((bodyId) => {
+    const body = getBodyById(bodyId);
+    if (!body) return;
+    setSelectedBodyId(bodyId);
+    const stored = bodyPositionsRef.current.get(bodyId);
+    if (stored) {
+      setFocusPosition([stored[0], stored[1], stored[2]]);
+    } else {
+      setFocusPosition([body.orbitRadius, 0, 0]);
+    }
+  }, []);
+
+  const handleMarkVisited = useCallback((bodyId) => {
+    const updated = markBodyVisited(bodyId);
+    setVisitedBodies(updated);
+  }, []);
+
+  const handleSelect = useCallback((body, worldPosition) => {
     setSelectedBodyId(body.id);
     setFocusPosition([worldPosition.x, worldPosition.y, worldPosition.z]);
-  }
+  }, []);
 
-  function handleExplore(body) {
-    const updated = markBodyVisited(body.id);
-    setVisitedBodies(updated);
-    navigate(`/explore/${body.id}`);
-  }
+  const handleExplore = useCallback(
+    (body) => {
+      handleMarkVisited(body.id);
+      navigate(`/explore/${body.id}`);
+    },
+    [handleMarkVisited, navigate]
+  );
+
+  const handleBeginExploration = useCallback(
+    (bodyId) => {
+      const body = getBodyById(bodyId);
+      if (body) {
+        handleExplore(body);
+      }
+    },
+    [handleExplore]
+  );
+
+  const selectedBody = getBodyById(selectedBodyId);
 
   const progressPercentage = Math.round((visitedBodies.size / celestialBodies.length) * 100);
 
@@ -148,43 +188,56 @@ export default function SolarSystemPage() {
         </button>
       </header>
       <main className="solar-main">
-        <Suspense fallback={<div className="solar-loading">Preparing star charts…</div>}>
-          <Canvas camera={{ position: [0, 12, 55], fov: 50 }} shadows>
-            <color attach="background" args={[0x02030f]} />
-            <ambientLight intensity={0.2} />
-            <pointLight position={[0, 0, 0]} intensity={2.5} color="#ffdca8" />
-            <Stars radius={120} depth={40} count={3000} factor={6} saturation={0} fade speed={0.5} />
-            {celestialBodies.map((body) => (
-              <CelestialBody
-                key={body.id}
-                body={body}
-                isSelected={body.id === selectedBodyId}
-                onSelect={handleSelect}
-                onExplore={handleExplore}
-              />
-            ))}
-            <CameraRig focusPosition={focusPosition} />
-            <OrbitControls enablePan={false} enableZoom enableDamping dampingFactor={0.1} minDistance={6} maxDistance={120} />
-          </Canvas>
-        </Suspense>
-        <aside className="solar-briefing" aria-live="polite">
-          {selectedBody ? (
-            <div>
-              <h2>{selectedBody.name} Mission Briefing</h2>
-              <p>{selectedBody.description}</p>
-              <ul>
-                {selectedBody.highlights.map((highlight) => (
-                  <li key={highlight}>{highlight}</li>
-                ))}
-              </ul>
-              <button className="primary" onClick={() => handleExplore(selectedBody)}>
-                Explore NASA Data
-              </button>
-            </div>
-          ) : (
-            <p>Select a body to view its briefing.</p>
-          )}
-        </aside>
+        <section className="solar-stage">
+          <Suspense fallback={<div className="solar-loading">Preparing star charts…</div>}>
+            <Canvas camera={{ position: [0, 12, 55], fov: 50 }} shadows>
+              <color attach="background" args={[0x02030f]} />
+              <ambientLight intensity={0.2} />
+              <pointLight position={[0, 0, 0]} intensity={2.5} color="#ffdca8" />
+              <Stars radius={120} depth={40} count={3000} factor={6} saturation={0} fade speed={0.5} />
+              {celestialBodies.map((body) => (
+                <CelestialBody
+                  key={body.id}
+                  body={body}
+                  isSelected={body.id === selectedBodyId}
+                  onSelect={handleSelect}
+                  onExplore={handleExplore}
+                  onPositionUpdate={handlePositionUpdate}
+                />
+              ))}
+              <CameraRig focusPosition={focusPosition} />
+              <OrbitControls enablePan={false} enableZoom enableDamping dampingFactor={0.1} minDistance={6} maxDistance={120} />
+            </Canvas>
+          </Suspense>
+        </section>
+        <div className="solar-sidebar">
+          <NavigationConsole
+            bodies={celestialBodies}
+            selectedBodyId={selectedBodyId}
+            visitedBodies={visitedBodies}
+            onSelectBody={handleConsoleSelect}
+            onMarkVisited={handleMarkVisited}
+            onBeginExploration={handleBeginExploration}
+          />
+          <aside className="solar-briefing" aria-live="polite">
+            {selectedBody ? (
+              <div>
+                <h2>{selectedBody.name} Mission Briefing</h2>
+                <p>{selectedBody.description}</p>
+                <ul>
+                  {selectedBody.highlights.map((highlight) => (
+                    <li key={highlight}>{highlight}</li>
+                  ))}
+                </ul>
+                <button className="primary" onClick={() => handleExplore(selectedBody)}>
+                  Explore NASA Data
+                </button>
+              </div>
+            ) : (
+              <p>Select a body to view its briefing.</p>
+            )}
+          </aside>
+        </div>
       </main>
     </div>
   );

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -375,7 +375,12 @@ button:disabled {
 .solar-main {
   flex: 1;
   display: grid;
-  grid-template-columns: minmax(0, 1fr) 360px;
+  grid-template-columns: minmax(0, 1fr) minmax(320px, 420px);
+  min-height: 0;
+}
+
+.solar-stage {
+  position: relative;
   min-height: 0;
 }
 
@@ -392,12 +397,28 @@ button:disabled {
   font-size: 1.2rem;
 }
 
-.solar-briefing {
+.solar-sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
   padding: 1.5rem;
   background: rgba(7, 12, 24, 0.88);
   border-left: 1px solid rgba(136, 192, 255, 0.12);
-  overflow-y: auto;
   backdrop-filter: blur(12px);
+  overflow-y: auto;
+  min-height: 0;
+}
+
+.solar-briefing {
+  background: rgba(9, 13, 24, 0.92);
+  border: 1px solid rgba(136, 192, 255, 0.16);
+  border-radius: 0.9rem;
+  padding: 1.25rem;
+  overflow-y: auto;
+  color: rgba(226, 234, 255, 0.92);
+  box-shadow: 0 18px 36px rgba(0, 0, 0, 0.35);
+  flex: 1 1 auto;
+  max-height: 100%;
 }
 
 .solar-briefing h2 {
@@ -407,6 +428,211 @@ button:disabled {
 .solar-briefing ul {
   padding-left: 1rem;
   line-height: 1.6;
+}
+
+.navigation-console {
+  background: rgba(9, 13, 24, 0.92);
+  border: 1px solid rgba(136, 192, 255, 0.16);
+  border-radius: 0.9rem;
+  padding: 1.2rem;
+  display: grid;
+  gap: 1rem;
+  box-shadow: 0 18px 36px rgba(0, 0, 0, 0.35);
+  color: rgba(224, 234, 255, 0.92);
+  flex: 0 0 auto;
+}
+
+.navigation-console header h2 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.navigation-console header p {
+  margin: 0.35rem 0 0;
+  font-size: 0.9rem;
+  color: rgba(199, 210, 255, 0.75);
+}
+
+.console-filter {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  font-size: 0.85rem;
+  color: rgba(223, 231, 255, 0.85);
+}
+
+.console-filter select {
+  background: rgba(11, 18, 34, 0.9);
+  border: 1px solid rgba(136, 192, 255, 0.32);
+  border-radius: 0.5rem;
+  padding: 0.4rem 0.6rem;
+  color: inherit;
+}
+
+.console-toggle {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.console-toggle button {
+  flex: 1;
+  background: rgba(15, 24, 46, 0.8);
+  border: 1px solid rgba(136, 192, 255, 0.18);
+  border-radius: 0.6rem;
+  padding: 0.45rem 0.6rem;
+  font-size: 0.8rem;
+}
+
+.console-toggle button.active {
+  background: rgba(115, 180, 255, 0.2);
+  border-color: rgba(136, 192, 255, 0.5);
+  box-shadow: 0 0 0 1px rgba(136, 192, 255, 0.35);
+}
+
+.console-active {
+  display: grid;
+  gap: 0.75rem;
+  background: rgba(13, 20, 38, 0.65);
+  border: 1px solid rgba(136, 192, 255, 0.12);
+  border-radius: 0.75rem;
+  padding: 0.75rem 0.9rem;
+}
+
+.console-active h3 {
+  margin: 0;
+  font-size: 0.95rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: rgba(199, 210, 255, 0.7);
+}
+
+.console-active p {
+  margin: 0.2rem 0 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: #f4f7ff;
+}
+
+.console-actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.console-actions button {
+  flex: 1;
+  min-width: 110px;
+}
+
+.console-manifest h4 {
+  margin: 0 0 0.5rem;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(199, 210, 255, 0.7);
+}
+
+.console-manifest ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.45rem;
+  max-height: 180px;
+  overflow-y: auto;
+}
+
+.console-manifest li button {
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: rgba(15, 22, 40, 0.7);
+  border: 1px solid transparent;
+  border-radius: 0.6rem;
+  padding: 0.55rem 0.7rem;
+  color: inherit;
+  text-align: left;
+  font-size: 0.85rem;
+}
+
+.console-manifest li button.active {
+  border-color: rgba(136, 192, 255, 0.5);
+  background: rgba(115, 180, 255, 0.22);
+}
+
+.console-manifest .badge {
+  background: rgba(136, 192, 255, 0.18);
+  color: rgba(211, 225, 255, 0.85);
+  padding: 0.1rem 0.45rem;
+  border-radius: 999px;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+}
+
+.console-empty {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(200, 210, 245, 0.7);
+}
+
+.console-card {
+  background: linear-gradient(135deg, rgba(77, 137, 255, 0.25), rgba(120, 85, 255, 0.2));
+  border: 1px solid rgba(136, 192, 255, 0.28);
+  border-radius: 0.85rem;
+  padding: 1rem;
+  display: grid;
+  gap: 0.75rem;
+  color: #f6fbff;
+  box-shadow: 0 14px 32px rgba(0, 0, 0, 0.35);
+}
+
+.console-card header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+}
+
+.console-card header h3 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.console-card header span {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  background: rgba(5, 10, 24, 0.35);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 999px;
+  padding: 0.15rem 0.6rem;
+}
+
+.console-card p {
+  margin: 0;
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+
+.console-card__actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.console-card__actions button {
+  flex: 1;
+  min-width: 140px;
+}
+
+.console-card.complete {
+  border-color: rgba(122, 216, 164, 0.6);
+  background: linear-gradient(135deg, rgba(73, 173, 112, 0.3), rgba(40, 83, 64, 0.4));
+}
+
+.console-card.complete header span {
+  background: rgba(26, 71, 48, 0.6);
+  border-color: rgba(122, 216, 164, 0.6);
 }
 
 .body-tooltip {
@@ -573,9 +799,34 @@ button:disabled {
     grid-template-columns: 1fr;
   }
 
-  .solar-briefing {
+  .solar-sidebar {
     border-left: none;
     border-top: 1px solid rgba(136, 192, 255, 0.12);
+    padding: 1.25rem;
+    gap: 1rem;
+  }
+}
+
+@media (min-width: 1280px) {
+  .solar-sidebar {
+    flex-direction: row;
+    align-items: stretch;
+    gap: 1.5rem;
+  }
+
+  .navigation-console {
+    flex: 0 0 300px;
+  }
+
+  .solar-briefing {
+    flex: 1 1 0;
+  }
+}
+
+@media (max-width: 600px) {
+  .console-actions button,
+  .console-card__actions button {
+    flex: 1 1 100%;
   }
 }
 


### PR DESCRIPTION
## Summary
- add a NavigationConsole component with filtering controls, visit toggle, and daily challenge surfaced from stored progress
- embed the console alongside the Three.js canvas on SolarSystemPage with shared focus and visit tracking handlers
- refresh the solar system styles to support the docked console layout and responsive behavior

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d80a9c4f9c832e96ea2f15ae55735a