### PR TITLE
Add mission control tabs to body detail view

### DIFF
--- a/frontend/src/pages/BodyDetailPage.jsx
+++ b/frontend/src/pages/BodyDetailPage.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { getBodyById } from '../data/celestialBodies.js';
-import { markBodyVisited } from '../utils/progress.js';
+import { getVisitedBodies, markBodyVisited } from '../utils/progress.js';
 import { useSpaceAudio } from '../state/SpaceAudioContext.js';
 
 function useDatasetsForBody(datasetCategory) {
@@ -96,6 +96,12 @@ function useMediaGallery(query) {
   return state;
 }
 
+const TAB_CONFIG = [
+  { id: 'datasets', label: 'Datasets', description: 'Mission telemetry & research feeds' },
+  { id: 'media', label: 'Media Gallery', description: 'Imagery and highlights from NASA archives' },
+  { id: 'missions', label: 'Missions', description: 'Run recon checklists to mark this world explored' }
+];
+
 export default function BodyDetailPage() {
   const { bodyId } = useParams();
   const navigate = useNavigate();
@@ -104,15 +110,112 @@ export default function BodyDetailPage() {
   const datasetState = useDatasetsForBody(body?.datasetCategory);
   const mediaState = useMediaGallery(body?.nasaQuery);
   const [apodState, setApodState] = useState({ status: 'idle', data: null });
+  const [activeTab, setActiveTab] = useState('datasets');
+  const [missions, setMissions] = useState([]);
+  const [isFullyExplored, setIsFullyExplored] = useState(false);
+
+  const missionTemplates = useMemo(() => {
+    if (!body) return [];
+
+    const genericMissions = [
+      {
+        id: 'scan-poles',
+        title: 'Scan the poles',
+        description: `Sweep ${body.name}'s polar regions for volatile deposits and hidden terrain features.`,
+        objectives: ['Calibrate orbital sensors', 'Execute north pole sweep', 'Execute south pole sweep']
+      },
+      {
+        id: 'terrain-map',
+        title: 'Compile landing zones',
+        description: `Assemble a hazard map of ${body.name}'s surface to brief landing teams and rover pilots.`,
+        objectives: ['Deploy surveyor drones', 'Stitch terrain mosaics', 'Flag hazards for mission control']
+      },
+      {
+        id: 'anomaly-pass',
+        title: 'Log anomaly pass',
+        description: `Record atmospheric or magnetospheric anomalies encountered near ${body.name}.`,
+        objectives: ['Run environmental diagnostics', 'Capture anomaly telemetry', 'Transmit findings to Deep Space Network']
+      }
+    ];
+
+    const specializedMissions = {
+      sun: [
+        {
+          id: 'coronal-weather',
+          title: 'Profile coronal weather',
+          description: 'Tune coronagraphs to isolate active regions driving solar wind streams.',
+          objectives: ['Stabilize spacecraft attitude', 'Capture coronal mass imagery', 'Update heliophysics forecast']
+        },
+        {
+          id: 'solar-flare-watch',
+          title: 'Solar flare watch',
+          description: 'Monitor x-ray flux for eruptive events that could impact communication arrays.',
+          objectives: ['Prime flare monitors', 'Log X-class candidates', 'Alert Deep Space Network teams']
+        },
+        {
+          id: 'magnetics',
+          title: 'Trace magnetic ribbons',
+          description: 'Model the twisting magnetic ribbons feeding the next flare cycle.',
+          objectives: ['Collect magnetogram series', 'Simulate flux emergence', 'Upload modeling results']
+        }
+      ],
+      moon: [
+        {
+          id: 'shadow-mapping',
+          title: 'Shadow crater mapping',
+          description: 'Illuminate permanently shadowed craters to confirm water-ice reservoirs.',
+          objectives: ['Point reflector arrays', 'Ping Shackleton rim', 'Catalog reflectance anomalies']
+        },
+        {
+          id: 'relay-test',
+          title: 'Artemis relay test',
+          description: 'Verify that the near-rectilinear halo orbit relay maintains downlink coverage.',
+          objectives: ['Align relay antennas', 'Test bandwidth thresholds', 'Report readiness to Gateway']
+        },
+        {
+          id: 'regolith',
+          title: 'Regolith sample rehearsal',
+          description: 'Practice the sampling choreography for upcoming crewed sorties.',
+          objectives: ['Position sample arm', 'Collect regolith simulant', 'Secure cache pods']
+        }
+      ]
+    };
+
+    return specializedMissions[body.id] ?? genericMissions;
+  }, [body]);
 
   useEffect(() => {
     start();
   }, [start]);
 
   useEffect(() => {
-    if (!bodyId) return;
-    markBodyVisited(bodyId);
-  }, [bodyId]);
+    if (!bodyId || missionTemplates.length === 0) return;
+
+    const visited = getVisitedBodies();
+    const alreadyExplored = visited.has(bodyId);
+
+    setIsFullyExplored(alreadyExplored);
+    setMissions(
+      missionTemplates.map((mission) => ({
+        ...mission,
+        objectives: mission.objectives.map((objective, index) => ({
+          id: `${mission.id}-${index}`,
+          label: objective,
+          completed: alreadyExplored
+        }))
+      }))
+    );
+  }, [bodyId, missionTemplates]);
+
+  useEffect(() => {
+    if (!bodyId || missions.length === 0) return;
+
+    const allComplete = missions.every((mission) => mission.objectives.every((objective) => objective.completed));
+    if (allComplete && !isFullyExplored) {
+      markBodyVisited(bodyId);
+      setIsFullyExplored(true);
+    }
+  }, [missions, bodyId, isFullyExplored]);
 
   useEffect(() => {
     if (!body || body.id !== 'sun') {
@@ -157,6 +260,33 @@ export default function BodyDetailPage() {
     );
   }
 
+  const handleObjectiveToggle = (missionId, objectiveId) => {
+    if (isFullyExplored) return;
+    setMissions((prev) =>
+      prev.map((mission) => {
+        if (mission.id !== missionId) return mission;
+        return {
+          ...mission,
+          objectives: mission.objectives.map((objective) =>
+            objective.id === objectiveId ? { ...objective, completed: !objective.completed } : objective
+          )
+        };
+      })
+    );
+  };
+
+  const handleAutoComplete = (missionId) => {
+    setMissions((prev) =>
+      prev.map((mission) => {
+        if (mission.id !== missionId) return mission;
+        return {
+          ...mission,
+          objectives: mission.objectives.map((objective) => ({ ...objective, completed: true }))
+        };
+      })
+    );
+  };
+
   return (
     <div className="body-detail">
       <header>
@@ -171,38 +301,141 @@ export default function BodyDetailPage() {
           ))}
         </ul>
       </section>
-      <section className="body-datasets">
-        <h2>NASA Datasets</h2>
-        {datasetState.status === 'loading' && <p>Retrieving datasets…</p>}
-        {datasetState.status === 'error' && <p className="error">{datasetState.error}</p>}
-        {datasetState.status === 'success' && datasetState.datasets.length === 0 && (
-          <p>No mission datasets yet — check back soon for new telemetry.</p>
-        )}
-        <div className="dataset-grid">
-          {datasetState.datasets.map((dataset) => (
-            <article key={dataset.id}>
-              <h3>{dataset.name}</h3>
-              <p>{dataset.description}</p>
-              {dataset.attribution && <p className="attribution">{dataset.attribution}</p>}
-            </article>
+      <section className="intel-tabs" aria-label="Exploration intelligence panels">
+        <div className="intel-tabs__list" role="tablist" aria-orientation="horizontal">
+          {TAB_CONFIG.map((tab) => (
+            <button
+              key={tab.id}
+              type="button"
+              role="tab"
+              id={`${tab.id}-tab`}
+              className={`tab-button${activeTab === tab.id ? ' is-active' : ''}`}
+              aria-selected={activeTab === tab.id}
+              aria-controls={`${tab.id}-panel`}
+              onClick={() => setActiveTab(tab.id)}
+            >
+              <span className="tab-button__label">{tab.label}</span>
+              <span className="tab-button__hint">{tab.description}</span>
+            </button>
           ))}
         </div>
-      </section>
-      <section className="body-media">
-        <h2>NASA Media Gallery</h2>
-        {mediaState.status === 'loading' && <p>Loading mission gallery…</p>}
-        {mediaState.status === 'error' && <p className="error">{mediaState.error}</p>}
-        {mediaState.status === 'success' && mediaState.items.length === 0 && <p>No imagery found for this target.</p>}
-        <div className="media-grid">
-          {mediaState.items.map((item) => (
-            <a key={item.id} href={item.href} target="_blank" rel="noreferrer" className="media-card">
-              <img src={item.href} alt={item.title} loading="lazy" />
-              <div>
-                <h3>{item.title}</h3>
-                {item.description && <p>{item.description.slice(0, 120)}…</p>}
+        <div className="intel-tabs__panels">
+          <div
+            role="tabpanel"
+            id="datasets-panel"
+            aria-labelledby="datasets-tab"
+            aria-hidden={activeTab !== 'datasets'}
+            tabIndex={activeTab === 'datasets' ? 0 : -1}
+            className={`tab-panel${activeTab === 'datasets' ? ' is-active' : ''}`}
+          >
+            <section className="body-datasets">
+              <h2>NASA Datasets</h2>
+              {datasetState.status === 'loading' && <p>Retrieving datasets…</p>}
+              {datasetState.status === 'error' && <p className="error">{datasetState.error}</p>}
+              {datasetState.status === 'success' && datasetState.datasets.length === 0 && (
+                <p>No mission datasets yet — check back soon for new telemetry.</p>
+              )}
+              <div className="dataset-grid">
+                {datasetState.datasets.map((dataset) => (
+                  <article key={dataset.id}>
+                    <h3>{dataset.name}</h3>
+                    <p>{dataset.description}</p>
+                    {dataset.attribution && <p className="attribution">{dataset.attribution}</p>}
+                  </article>
+                ))}
               </div>
-            </a>
-          ))}
+            </section>
+          </div>
+          <div
+            role="tabpanel"
+            id="media-panel"
+            aria-labelledby="media-tab"
+            aria-hidden={activeTab !== 'media'}
+            tabIndex={activeTab === 'media' ? 0 : -1}
+            className={`tab-panel${activeTab === 'media' ? ' is-active' : ''}`}
+          >
+            <section className="body-media">
+              <h2>NASA Media Gallery</h2>
+              {mediaState.status === 'loading' && <p>Loading mission gallery…</p>}
+              {mediaState.status === 'error' && <p className="error">{mediaState.error}</p>}
+              {mediaState.status === 'success' && mediaState.items.length === 0 && <p>No imagery found for this target.</p>}
+              <div className="media-grid">
+                {mediaState.items.map((item) => (
+                  <a key={item.id} href={item.href} target="_blank" rel="noreferrer" className="media-card">
+                    <img src={item.href} alt={item.title} loading="lazy" />
+                    <div>
+                      <h3>{item.title}</h3>
+                      {item.description && <p>{item.description.slice(0, 120)}…</p>}
+                    </div>
+                  </a>
+                ))}
+              </div>
+            </section>
+          </div>
+          <div
+            role="tabpanel"
+            id="missions-panel"
+            aria-labelledby="missions-tab"
+            aria-hidden={activeTab !== 'missions'}
+            tabIndex={activeTab === 'missions' ? 0 : -1}
+            className={`tab-panel${activeTab === 'missions' ? ' is-active' : ''}`}
+          >
+            <section className="body-missions">
+              <h2>Mission Checklists</h2>
+              <p>
+                Complete each objective to simulate the reconnaissance routines for {body.name}. When every checklist item is
+                verified, the body is flagged as fully explored in your mission log.
+              </p>
+              {missions.length > 0 ? (
+                <ul className="mission-list">
+                  {missions.map((mission) => {
+                    const completedObjectives = mission.objectives.filter((objective) => objective.completed).length;
+                    const statusLabel =
+                      completedObjectives === mission.objectives.length
+                        ? 'Completed'
+                        : completedObjectives > 0
+                        ? 'In progress'
+                        : 'Awaiting launch';
+
+                    return (
+                      <li key={mission.id} className={`mission-card mission-card--${statusLabel.replace(/\s+/g, '-').toLowerCase()}`}>
+                        <header>
+                          <h3>{mission.title}</h3>
+                          <span className="mission-status">{statusLabel}</span>
+                        </header>
+                        <p>{mission.description}</p>
+                        <div className="mission-objectives" role="group" aria-label={`${mission.title} objectives`}>
+                          {mission.objectives.map((objective) => (
+                            <label key={objective.id} className={objective.completed ? 'is-complete' : ''}>
+                              <input
+                                type="checkbox"
+                                disabled={isFullyExplored}
+                                checked={objective.completed}
+                                onChange={() => handleObjectiveToggle(mission.id, objective.id)}
+                              />
+                              <span>{objective.label}</span>
+                            </label>
+                          ))}
+                        </div>
+                        {!isFullyExplored && completedObjectives < mission.objectives.length && (
+                          <button type="button" className="secondary" onClick={() => handleAutoComplete(mission.id)}>
+                            Run quick simulation
+                          </button>
+                        )}
+                      </li>
+                    );
+                  })}
+                </ul>
+              ) : (
+                <p className="muted">Mission control is loading tailored objectives…</p>
+              )}
+              {isFullyExplored && (
+                <div className="mission-complete">
+                  <strong>✅ Fully explored.</strong> {body.name} is archived as complete in your mission history.
+                </div>
+              )}
+            </section>
+          </div>
         </div>
       </section>
       {body.id === 'sun' && (

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -468,6 +468,88 @@ button:disabled {
   color: rgba(215, 224, 255, 0.85);
 }
 
+.intel-tabs {
+  background: rgba(9, 14, 28, 0.88);
+  border: 1px solid rgba(136, 192, 255, 0.18);
+  border-radius: 1.3rem;
+  padding: clamp(1rem, 2vw, 1.5rem);
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  box-shadow: 0 20px 42px rgba(4, 8, 18, 0.45);
+}
+
+.intel-tabs__list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 0.75rem;
+}
+
+.tab-button {
+  cursor: pointer;
+  text-align: left;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  border-radius: 0.85rem;
+  border: 1px solid rgba(136, 192, 255, 0.18);
+  background: rgba(13, 22, 42, 0.75);
+  color: rgba(222, 233, 255, 0.9);
+  padding: 0.85rem 1rem;
+  transition: border 0.2s ease, background 0.25s ease, transform 0.2s ease, box-shadow 0.25s ease;
+}
+
+.tab-button__label {
+  font-size: 0.95rem;
+  font-weight: 600;
+}
+
+.tab-button__hint {
+  font-size: 0.75rem;
+  color: rgba(198, 211, 255, 0.7);
+}
+
+.tab-button:hover,
+.tab-button.is-active {
+  border-color: rgba(148, 255, 197, 0.45);
+  background: linear-gradient(135deg, rgba(29, 51, 89, 0.95), rgba(19, 38, 70, 0.95));
+  box-shadow: 0 10px 24px rgba(10, 18, 36, 0.4);
+  transform: translateY(-1px);
+}
+
+.tab-button[aria-selected='true'] {
+  color: #f8fbff;
+}
+
+.tab-button:focus-visible {
+  outline: 3px solid rgba(148, 255, 197, 0.8);
+  outline-offset: 2px;
+}
+
+.intel-tabs__panels {
+  display: grid;
+}
+
+.tab-panel {
+  background: rgba(7, 13, 28, 0.78);
+  border: 1px solid rgba(136, 192, 255, 0.16);
+  border-radius: 1.1rem;
+  padding: clamp(1rem, 2.5vw, 1.75rem);
+  opacity: 0;
+  transform: translateY(12px);
+  pointer-events: none;
+  visibility: hidden;
+  transition: opacity 0.3s ease, transform 0.35s ease, box-shadow 0.35s ease;
+}
+
+.tab-panel.is-active {
+  opacity: 1;
+  transform: translateY(0);
+  pointer-events: auto;
+  visibility: visible;
+  box-shadow: 0 14px 28px rgba(8, 12, 24, 0.5);
+}
+
 .body-datasets .dataset-grid {
   display: grid;
   gap: 1rem;
@@ -492,6 +574,115 @@ button:disabled {
   display: grid;
   gap: 1rem;
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.body-missions {
+  display: grid;
+  gap: 1rem;
+}
+
+.body-missions h2 {
+  margin-bottom: 0.25rem;
+}
+
+.body-missions p {
+  margin: 0;
+  color: rgba(202, 214, 255, 0.78);
+  line-height: 1.6;
+}
+
+.mission-list {
+  list-style: none;
+  margin: 1.25rem 0 0;
+  padding: 0;
+  display: grid;
+  gap: 1rem;
+}
+
+.mission-card {
+  background: rgba(10, 17, 35, 0.88);
+  border: 1px solid rgba(136, 192, 255, 0.16);
+  border-radius: 1rem;
+  padding: 1.1rem 1.25rem;
+  display: grid;
+  gap: 0.75rem;
+  transition: border 0.2s ease, box-shadow 0.3s ease, transform 0.25s ease;
+}
+
+.mission-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 24px rgba(8, 12, 24, 0.4);
+}
+
+.mission-card header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 0.75rem;
+}
+
+.mission-status {
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(148, 255, 197, 0.75);
+}
+
+.mission-card--awaiting-launch .mission-status {
+  color: rgba(136, 192, 255, 0.6);
+}
+
+.mission-card--awaiting-launch {
+  border-color: rgba(136, 192, 255, 0.18);
+}
+
+.mission-card--in-progress {
+  border-color: rgba(148, 255, 197, 0.35);
+}
+
+.mission-card--completed {
+  border-color: rgba(148, 255, 197, 0.6);
+  background: linear-gradient(135deg, rgba(14, 36, 48, 0.92), rgba(17, 52, 62, 0.88));
+}
+
+.mission-objectives {
+  display: grid;
+  gap: 0.45rem;
+}
+
+.mission-objectives label {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  align-items: center;
+  gap: 0.6rem;
+  font-size: 0.85rem;
+  color: rgba(202, 214, 255, 0.85);
+}
+
+.mission-objectives input[type='checkbox'] {
+  width: 1rem;
+  height: 1rem;
+  accent-color: #88ffc5;
+  cursor: pointer;
+}
+
+.mission-objectives label.is-complete span {
+  color: rgba(148, 255, 197, 0.82);
+  text-decoration: none;
+}
+
+.mission-complete {
+  margin-top: 1rem;
+  padding: 0.75rem 1rem;
+  border-radius: 0.85rem;
+  background: rgba(20, 42, 52, 0.9);
+  border: 1px solid rgba(148, 255, 197, 0.4);
+  color: rgba(210, 244, 233, 0.95);
+  font-size: 0.9rem;
+}
+
+.muted {
+  color: rgba(175, 189, 229, 0.65);
 }
 
 .media-card {


### PR DESCRIPTION
## Summary
- replace the dataset and media sections on the body detail view with an IntelTabs tab set that includes a new missions panel
- scaffold interactive mission checklists that record objectives and only mark a body explored once every task is complete
- style the new tab navigation and mission modules to feel like control-room interfaces with focus-visible treatments and transitions

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d80a9dce48832ebba0b2ace3295b21