### PR TITLE
Fix color-space handling for texture maps

### DIFF
--- a/frontend/src/pages/SolarSystemPage.jsx
+++ b/frontend/src/pages/SolarSystemPage.jsx
@@ -77,6 +77,42 @@ function CelestialBody({ body, isSelected, onSelect, onExplore, onPositionUpdate
     };
   }, [ringTexture]);
 
+  const textureMaps = body.textureMaps;
+
+  useEffect(() => {
+    if (!textureMaps) {
+      return undefined;
+    }
+
+    const entries =
+      textureMaps instanceof Map
+        ? Array.from(textureMaps.entries())
+        : Object.entries(textureMaps);
+
+    entries.forEach(([mapType, texture]) => {
+      if (!(texture instanceof THREE.Texture)) {
+        return;
+      }
+
+      const normalizedType = String(mapType).toLowerCase();
+      const isNormalMap = normalizedType.includes('normal');
+      const isColorBearing =
+        normalizedType.includes('diffuse') ||
+        normalizedType.includes('emissive') ||
+        normalizedType.includes('albedo') ||
+        normalizedType.includes('color');
+
+      if (!isColorBearing || isNormalMap) {
+        return;
+      }
+
+      texture.colorSpace = THREE.SRGBColorSpace;
+      texture.needsUpdate = true;
+    });
+
+    return undefined;
+  }, [textureMaps]);
+
   useEffect(() => {
     if (tiltGroupRef.current) {
       tiltGroupRef.current.rotation.z = THREE.MathUtils.degToRad(body.axialTilt || 0);


### PR DESCRIPTION
## Summary
- ensure the texture post-processing step only marks color-bearing maps (diffuse/emissive) as sRGB
- leave the normal map entry in linear space by skipping it during color-space updates

## Testing
- npm run dev -- --host 0.0.0.0 --port 4173

------
https://chatgpt.com/codex/tasks/task_b_68d8144a3728832eb7e8412728a0c6f5