### PR TITLE
refactor: support user supplied celestial textures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@ frontend/dist
 npm-debug.log*
 yarn-error.log*
 pnpm-debug.log*
+
+# Local high-resolution textures supplied out of band
+frontend/src/assets/textures/*
+!frontend/src/assets/textures/.gitkeep

--- a/frontend/src/data/celestialBodies.js
+++ b/frontend/src/data/celestialBodies.js
@@ -1,12 +1,76 @@
-export const celestialBodies = [
+const DISTANCE_LOG_FACTOR = 5;
+const DISTANCE_SCALE = 22;
+const ORBITAL_DAY_SCALE = 2.1;
+const ROTATION_HOUR_SCALE = 13;
+const MOON_DISTANCE_SCALE = 0.000009;
+const DEG_TO_RAD = Math.PI / 180;
+
+function scaleOrbitDistance({ au, km }) {
+  if (typeof au === 'number') {
+    if (au === 0) return 0;
+    return Math.log10(1 + au * DISTANCE_LOG_FACTOR) * DISTANCE_SCALE;
+  }
+  if (typeof km === 'number') {
+    if (km === 0) return 0;
+    return km * MOON_DISTANCE_SCALE;
+  }
+  return 0;
+}
+
+function computeRotationRate(rotationPeriodHours = 0) {
+  if (!rotationPeriodHours) {
+    return 0;
+  }
+  const direction = rotationPeriodHours < 0 ? -1 : 1;
+  const period = Math.abs(rotationPeriodHours);
+  return (direction * 2 * Math.PI) / (period * ROTATION_HOUR_SCALE);
+}
+
+function computeOrbitRate(orbitalPeriodDays = 0) {
+  if (!orbitalPeriodDays) {
+    return 0;
+  }
+  return (2 * Math.PI) / (orbitalPeriodDays * ORBITAL_DAY_SCALE);
+}
+
+function prepareBody(body) {
+  const semiMajorAxis = body.semiMajorAxis;
+  const eccentricity = body.eccentricity ?? 0;
+  const semiMinorAxis = semiMajorAxis * Math.sqrt(1 - eccentricity * eccentricity);
+  const axialTilt = body.axialTilt ?? 0;
+  const inclination = body.inclination ?? 0;
+
+  return {
+    ...body,
+    semiMajorAxis,
+    semiMinorAxis,
+    orbitRate: computeOrbitRate(body.orbitalPeriodDays),
+    rotationRate: computeRotationRate(body.rotationPeriodHours),
+    axialTilt,
+    axialTiltRad: axialTilt * DEG_TO_RAD,
+    inclination,
+    inclinationRad: inclination * DEG_TO_RAD
+  };
+}
+
+// Texture keys correspond to filenames (with or without extensions) in
+// `frontend/src/assets/textures/`. The actual binary assets are supplied
+// locally and ignored by Git.
+const rawBodies = [
   {
     id: 'sun',
     name: 'Sun',
     color: '#f7b733',
-    orbitRadius: 0,
+    textureKey: null,
+    normalMapKey: null,
+    emissiveMapKey: 'sun-emissive',
     size: 4.5,
-    orbitSpeed: 0,
-    rotationSpeed: 0.0005,
+    semiMajorAxis: 0,
+    eccentricity: 0,
+    orbitalPeriodDays: 0,
+    rotationPeriodHours: 609.12,
+    axialTilt: 7.25,
+    inclination: 0,
     description:
       'Our local star powers life on Earth and drives space weather across the solar system. Its surface boils with convection cells while solar flares hurl charged particles into space.',
     highlights: [
@@ -21,12 +85,18 @@ export const celestialBodies = [
     id: 'mercury',
     name: 'Mercury',
     color: '#b5b3aa',
-    orbitRadius: 9,
+    textureKey: null,
+    normalMapKey: null,
+    emissiveMapKey: null,
     size: 0.4,
-    orbitSpeed: 0.012,
-    rotationSpeed: 0.001,
+    semiMajorAxis: scaleOrbitDistance({ au: 0.387 }),
+    eccentricity: 0.2056,
+    orbitalPeriodDays: 87.969,
+    rotationPeriodHours: 1407.5,
+    axialTilt: 0.034,
+    inclination: 7.0,
     description:
-      'Mercury is a heavily cratered world with extreme temperature swings. NASA\'s MESSENGER mission mapped its surface and studied its magnetic field.',
+      "Mercury is a heavily cratered world with extreme temperature swings. NASA's MESSENGER mission mapped its surface and studied its magnetic field.",
     highlights: [
       'Smallest planet in the solar system.',
       'Orbital period of 88 Earth days.',
@@ -39,10 +109,16 @@ export const celestialBodies = [
     id: 'venus',
     name: 'Venus',
     color: '#e6c15a',
-    orbitRadius: 13,
+    textureKey: null,
+    normalMapKey: null,
+    emissiveMapKey: null,
     size: 0.95,
-    orbitSpeed: 0.0095,
-    rotationSpeed: 0.0008,
+    semiMajorAxis: scaleOrbitDistance({ au: 0.723 }),
+    eccentricity: 0.0068,
+    orbitalPeriodDays: 224.701,
+    rotationPeriodHours: -5832.5,
+    axialTilt: 177.36,
+    inclination: 3.39,
     description:
       'Venus is a greenhouse world enveloped by thick clouds. Radar mapping by Magellan reveals volcanoes, mountains, and tectonic plains beneath the haze.',
     highlights: [
@@ -57,10 +133,16 @@ export const celestialBodies = [
     id: 'earth',
     name: 'Earth',
     color: '#2f8ae6',
-    orbitRadius: 18,
+    textureKey: 'earth-diffuse',
+    normalMapKey: 'earth-normal',
+    emissiveMapKey: null,
     size: 1,
-    orbitSpeed: 0.008,
-    rotationSpeed: 0.02,
+    semiMajorAxis: scaleOrbitDistance({ au: 1 }),
+    eccentricity: 0.0167,
+    orbitalPeriodDays: 365.256,
+    rotationPeriodHours: 23.934,
+    axialTilt: 23.44,
+    inclination: 0,
     description:
       'Earth is a water-rich, life-supporting world with dynamic weather, plate tectonics, and a protective magnetic field. NASA operates dozens of missions to monitor its systems.',
     highlights: [
@@ -75,10 +157,17 @@ export const celestialBodies = [
     id: 'moon',
     name: 'Moon',
     color: '#cfd2d7',
-    orbitRadius: 22,
+    textureKey: null,
+    normalMapKey: null,
+    emissiveMapKey: null,
     size: 0.27,
-    orbitSpeed: 0.0085,
-    rotationSpeed: 0.01,
+    semiMajorAxis: scaleOrbitDistance({ km: 384400 }),
+    eccentricity: 0.0549,
+    orbitalPeriodDays: 27.321,
+    rotationPeriodHours: 655.7,
+    axialTilt: 6.68,
+    inclination: 5.145,
+    parentId: 'earth',
     description:
       "Earth's Moon preserves a record of early solar-system history. Lunar Reconnaissance Orbiter continues to deliver topographic maps and ultra-high-resolution imagery.",
     highlights: [
@@ -93,10 +182,16 @@ export const celestialBodies = [
     id: 'mars',
     name: 'Mars',
     color: '#d05d3b',
-    orbitRadius: 26,
+    textureKey: null,
+    normalMapKey: null,
+    emissiveMapKey: null,
     size: 0.53,
-    orbitSpeed: 0.0065,
-    rotationSpeed: 0.015,
+    semiMajorAxis: scaleOrbitDistance({ au: 1.524 }),
+    eccentricity: 0.0934,
+    orbitalPeriodDays: 686.98,
+    rotationPeriodHours: 24.623,
+    axialTilt: 25.19,
+    inclination: 1.85,
     description:
       'Mars features towering volcanoes, ancient river deltas, and seasons similar to Earth. NASA rovers and orbiters study its past habitability and climate evolution.',
     highlights: [
@@ -111,12 +206,18 @@ export const celestialBodies = [
     id: 'jupiter',
     name: 'Jupiter',
     color: '#c58f5d',
-    orbitRadius: 33,
+    textureKey: 'jupiter-diffuse',
+    normalMapKey: null,
+    emissiveMapKey: null,
     size: 2.5,
-    orbitSpeed: 0.004,
-    rotationSpeed: 0.03,
+    semiMajorAxis: scaleOrbitDistance({ au: 5.203 }),
+    eccentricity: 0.0489,
+    orbitalPeriodDays: 4332.59,
+    rotationPeriodHours: 9.925,
+    axialTilt: 3.13,
+    inclination: 1.304,
     description:
-      'The largest planet is a gas giant with swirling belts and the famous Great Red Spot. NASA\'s Juno mission peers beneath its cloud tops.',
+      "The largest planet is a gas giant with swirling belts and the famous Great Red Spot. NASA's Juno mission peers beneath its cloud tops.",
     highlights: [
       'Has at least 79 moons, including volcanic Io and icy Europa.',
       'Immense magnetosphere extends millions of kilometers.',
@@ -129,10 +230,26 @@ export const celestialBodies = [
     id: 'saturn',
     name: 'Saturn',
     color: '#f3d38c',
-    orbitRadius: 39,
+    textureKey: null,
+    normalMapKey: null,
+    emissiveMapKey: null,
     size: 2.2,
-    orbitSpeed: 0.003,
-    rotationSpeed: 0.028,
+    semiMajorAxis: scaleOrbitDistance({ au: 9.582 }),
+    eccentricity: 0.0565,
+    orbitalPeriodDays: 10759.22,
+    rotationPeriodHours: 10.656,
+    axialTilt: 26.73,
+    inclination: 2.485,
+    rings: {
+      innerRadius: 3.2,
+      outerRadius: 4.6,
+      colorStops: [
+        { offset: 0, color: 'rgba(255, 255, 255, 0.1)' },
+        { offset: 0.35, color: 'rgba(243, 211, 140, 0.45)' },
+        { offset: 0.65, color: 'rgba(212, 178, 120, 0.55)' },
+        { offset: 1, color: 'rgba(255, 255, 255, 0.1)' }
+      ]
+    },
     description:
       'Saturn is adorned with icy rings and moons like Titan and Enceladus. The Cassini mission revealed active geysers and complex atmospheric patterns.',
     highlights: [
@@ -147,10 +264,25 @@ export const celestialBodies = [
     id: 'uranus',
     name: 'Uranus',
     color: '#78d0e3',
-    orbitRadius: 45,
+    textureKey: null,
+    normalMapKey: null,
+    emissiveMapKey: null,
     size: 1.9,
-    orbitSpeed: 0.0024,
-    rotationSpeed: 0.02,
+    semiMajorAxis: scaleOrbitDistance({ au: 19.189 }),
+    eccentricity: 0.0472,
+    orbitalPeriodDays: 30685.4,
+    rotationPeriodHours: -17.24,
+    axialTilt: 97.77,
+    inclination: 0.773,
+    rings: {
+      innerRadius: 2.4,
+      outerRadius: 3.1,
+      colorStops: [
+        { offset: 0, color: 'rgba(180, 220, 255, 0.05)' },
+        { offset: 0.5, color: 'rgba(120, 190, 230, 0.25)' },
+        { offset: 1, color: 'rgba(180, 220, 255, 0.05)' }
+      ]
+    },
     description:
       'An ice giant tipped on its side, Uranus has extreme seasons and a faint ring system. Voyager 2 remains the only spacecraft to have visited it.',
     highlights: [
@@ -165,12 +297,18 @@ export const celestialBodies = [
     id: 'neptune',
     name: 'Neptune',
     color: '#3f6dd5',
-    orbitRadius: 52,
+    textureKey: null,
+    normalMapKey: null,
+    emissiveMapKey: null,
     size: 1.8,
-    orbitSpeed: 0.002,
-    rotationSpeed: 0.019,
+    semiMajorAxis: scaleOrbitDistance({ au: 30.07 }),
+    eccentricity: 0.0086,
+    orbitalPeriodDays: 60190,
+    rotationPeriodHours: 16.11,
+    axialTilt: 28.32,
+    inclination: 1.77,
     description:
-      'Neptune is a windy ice giant with supersonic storms. Voyager 2 revealed its dynamic atmosphere and the moon Triton\'s icy geysers.',
+      "Neptune is a windy ice giant with supersonic storms. Voyager 2 revealed its dynamic atmosphere and the moon Triton's icy geysers.",
     highlights: [
       'Fastest winds in the solar system, exceeding 1,900 km/h.',
       'Deep blue color comes from methane in the atmosphere.',
@@ -180,6 +318,8 @@ export const celestialBodies = [
     nasaQuery: 'Neptune Voyager Triton'
   }
 ];
+
+export const celestialBodies = rawBodies.map((body) => prepareBody(body));
 
 export function getBodyById(bodyId) {
   return celestialBodies.find((body) => body.id === bodyId);

--- a/frontend/src/pages/SolarSystemPage.jsx
+++ b/frontend/src/pages/SolarSystemPage.jsx
@@ -205,6 +205,20 @@ function CelestialBody({
 
   const emissiveColor = body.id === 'sun' ? '#f8a04a' : '#090b1a';
   const emissiveIntensity = body.id === 'sun' ? 1.15 : 0.08;
+  const atmosphereSettings = body.atmosphere ?? {};
+  const showAtmosphere = atmosphereSettings.enabled ?? body.id !== 'sun';
+  const atmosphereScale = atmosphereSettings.scale ?? (body.id === 'sun' ? 1 : 1.05);
+  const atmosphereOpacity = atmosphereSettings.opacity ?? (body.id === 'sun' ? 0.12 : 0.18);
+  const atmosphereEmissiveIntensity =
+    atmosphereSettings.emissiveIntensity ?? (body.id === 'sun' ? 0.4 : 0.35);
+
+  const rimColor = useMemo(() => {
+    const fallback = new THREE.Color('#ffffff');
+    const base = new THREE.Color(body.color ?? '#ffffff');
+    const rim = base.clone().lerp(fallback, 0.35);
+    return `#${rim.getHexString()}`;
+  }, [body.color]);
+  const atmosphereColor = atmosphereSettings.color ?? rimColor;
 
   return (
     <>
@@ -248,6 +262,20 @@ function CelestialBody({
               roughness={0.85}
               metalness={0.1}
             />
+            {showAtmosphere && (
+              <mesh scale={atmosphereScale} frustumCulled={false}>
+                <sphereGeometry args={[body.size, 32, 32]} />
+                <meshPhongMaterial
+                  color={atmosphereColor}
+                  emissive={atmosphereColor}
+                  emissiveIntensity={atmosphereEmissiveIntensity}
+                  transparent
+                  opacity={atmosphereOpacity}
+                  blending={THREE.AdditiveBlending}
+                  side={THREE.BackSide}
+                />
+              </mesh>
+            )}
             {body.rings && ringTexture && (
               <mesh rotation={[Math.PI / 2, 0, 0]}>
                 <ringGeometry args={[body.rings.innerRadius, body.rings.outerRadius, 128]} />

--- a/frontend/src/pages/SolarSystemPage.jsx
+++ b/frontend/src/pages/SolarSystemPage.jsx
@@ -1,90 +1,278 @@
-import { Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { Canvas, useFrame, useThree } from '@react-three/fiber';
+import { Suspense, forwardRef, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Canvas, useFrame, useLoader, useThree } from '@react-three/fiber';
 import { Html, OrbitControls, Stars } from '@react-three/drei';
 import * as THREE from 'three';
+import { TextureLoader } from 'three';
 import { useNavigate } from 'react-router-dom';
 import { celestialBodies, getBodyById } from '../data/celestialBodies.js';
 import { getVisitedBodies, markBodyVisited } from '../utils/progress.js';
+import { buildTextureSet } from '../utils/textureRegistry.js';
 import { useSpaceAudio } from '../state/SpaceAudioContext.js';
 import NavigationConsole from '../components/NavigationConsole.jsx';
 
-function OrbitRing({ radius }) {
+const EMPTY_TEXTURE_DATA_URL =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M/wHwAFhAKK4PvJ4wAAAABJRU5ErkJggg==';
+
+const OrbitRing = forwardRef(function OrbitRing({ semiMajor, semiMinor, inclination = 0 }, ref) {
   const points = useMemo(() => {
-    const segments = 64;
+    if (!semiMajor || !semiMinor) return [];
+    const segments = 128;
     const pts = [];
+    const inclinationRad = THREE.MathUtils.degToRad(inclination);
+    const cosInc = Math.cos(inclinationRad);
+    const sinInc = Math.sin(inclinationRad);
     for (let i = 0; i <= segments; i += 1) {
       const theta = (i / segments) * Math.PI * 2;
-      pts.push(new THREE.Vector3(Math.cos(theta) * radius, 0, Math.sin(theta) * radius));
+      const x = semiMajor * Math.cos(theta);
+      const z = semiMinor * Math.sin(theta);
+      const y = z * sinInc;
+      const zInclined = z * cosInc;
+      pts.push(new THREE.Vector3(x, y, zInclined));
     }
     return pts;
-  }, [radius]);
+  }, [semiMajor, semiMinor, inclination]);
+
+  if (!points.length) {
+    return null;
+  }
 
   return (
-    <lineLoop>
-      <bufferGeometry attach="geometry" setFromPoints={points} />
-      <lineBasicMaterial attach="material" color="#3b4262" linewidth={1} />
-    </lineLoop>
+    <group ref={ref}>
+      <lineLoop>
+        <bufferGeometry attach="geometry" setFromPoints={points} />
+        <lineBasicMaterial attach="material" color="#3b4262" linewidth={1} />
+      </lineLoop>
+    </group>
   );
-}
+});
 
-function CelestialBody({ body, isSelected, onSelect, onExplore, onPositionUpdate }) {
+function CelestialBody({
+  body,
+  isSelected,
+  onSelect,
+  onExplore,
+  onPositionUpdate,
+  getBodyPosition
+}) {
   const groupRef = useRef();
   const meshRef = useRef();
+  const tiltGroupRef = useRef();
+  const orbitRingRef = useRef();
   const worldPosition = useRef(new THREE.Vector3());
   const orbitalPosition = useRef(new THREE.Vector3());
+  const orbitAngle = useRef(Math.random() * Math.PI * 2);
+  const { gl } = useThree();
+
+  const textureSources = useMemo(
+    () =>
+      buildTextureSet({
+        textureKey: body.textureKey,
+        normalMapKey: body.normalMapKey,
+        emissiveMapKey: body.emissiveMapKey
+      }),
+    [body.emissiveMapKey, body.normalMapKey, body.textureKey]
+  );
+
+  const hasDiffuseTexture = Boolean(textureSources.map);
+  const hasNormalMap = Boolean(textureSources.normalMap);
+  const hasEmissiveMap = Boolean(textureSources.emissiveMap);
+
+  const diffuseMap = useLoader(
+    TextureLoader,
+    hasDiffuseTexture ? textureSources.map : EMPTY_TEXTURE_DATA_URL
+  );
+  const normalMap = useLoader(
+    TextureLoader,
+    hasNormalMap ? textureSources.normalMap : EMPTY_TEXTURE_DATA_URL
+  );
+  const emissiveMap = useLoader(
+    TextureLoader,
+    hasEmissiveMap ? textureSources.emissiveMap : EMPTY_TEXTURE_DATA_URL
+  );
+
+  useEffect(() => {
+    if (!hasDiffuseTexture && diffuseMap) {
+      diffuseMap.dispose();
+    }
+    if (!hasNormalMap && normalMap) {
+      normalMap.dispose();
+    }
+    if (!hasEmissiveMap && emissiveMap) {
+      emissiveMap.dispose();
+    }
+    return () => {
+      if (diffuseMap) diffuseMap.dispose();
+      if (normalMap) normalMap.dispose();
+      if (emissiveMap) emissiveMap.dispose();
+    };
+  }, [diffuseMap, emissiveMap, hasDiffuseTexture, hasEmissiveMap, hasNormalMap, normalMap]);
+
+  useEffect(() => {
+    const maxAnisotropy = Math.min(gl.capabilities.getMaxAnisotropy?.() ?? 1, 16);
+    if (hasDiffuseTexture && diffuseMap) {
+      diffuseMap.anisotropy = maxAnisotropy;
+      diffuseMap.colorSpace = THREE.SRGBColorSpace;
+      diffuseMap.needsUpdate = true;
+    }
+    if (hasEmissiveMap && emissiveMap) {
+      emissiveMap.anisotropy = maxAnisotropy;
+      emissiveMap.colorSpace = THREE.SRGBColorSpace;
+      emissiveMap.needsUpdate = true;
+    }
+    if (hasNormalMap && normalMap) {
+      normalMap.anisotropy = maxAnisotropy;
+      normalMap.needsUpdate = true;
+    }
+  }, [diffuseMap, emissiveMap, gl, hasDiffuseTexture, hasEmissiveMap, hasNormalMap, normalMap]);
+
+  useEffect(() => {
+    if (tiltGroupRef.current) {
+      tiltGroupRef.current.rotation.z = body.axialTiltRad ?? 0;
+    }
+  }, [body.axialTiltRad]);
+
+  const ringTexture = useMemo(() => {
+    if (!body.rings) return null;
+    if (typeof document === 'undefined') return null;
+    const size = 512;
+    const canvas = document.createElement('canvas');
+    canvas.width = size;
+    canvas.height = size;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return null;
+    const gradient = ctx.createRadialGradient(size / 2, size / 2, size * 0.2, size / 2, size / 2, size / 2);
+    body.rings.colorStops.forEach((stop) => {
+      gradient.addColorStop(stop.offset, stop.color);
+    });
+    ctx.fillStyle = gradient;
+    ctx.fillRect(0, 0, size, size);
+    const texture = new THREE.CanvasTexture(canvas);
+    texture.colorSpace = THREE.SRGBColorSpace;
+    texture.needsUpdate = true;
+    return texture;
+  }, [body.rings]);
+
+  useEffect(() => {
+    if (!ringTexture) return undefined;
+    return () => {
+      ringTexture.dispose();
+    };
+  }, [ringTexture]);
 
   useFrame(({ clock }) => {
-    const elapsed = clock.getElapsedTime();
-    const orbitAngle = elapsed * body.orbitSpeed;
-    const x = Math.cos(orbitAngle) * body.orbitRadius;
-    const z = Math.sin(orbitAngle) * body.orbitRadius;
-    if (groupRef.current) {
-      groupRef.current.position.set(x, 0, z);
+    const delta = clock.getDelta();
+    orbitAngle.current += body.orbitRate * delta;
+    const angle = orbitAngle.current;
+    const x = body.semiMajorAxis * Math.cos(angle);
+    const z = body.semiMinorAxis * Math.sin(angle);
+    const inclinationRad = body.inclinationRad || 0;
+    const y = z * Math.sin(inclinationRad);
+    const zInclined = z * Math.cos(inclinationRad);
+
+    orbitalPosition.current.set(x, y, zInclined);
+    let parentCoords = null;
+
+    if (body.parentId && getBodyPosition) {
+      const parent = getBodyPosition(body.parentId);
+      if (parent) {
+        parentCoords = parent;
+        orbitalPosition.current.x += parent[0];
+        orbitalPosition.current.y += parent[1];
+        orbitalPosition.current.z += parent[2];
+      }
     }
-    orbitalPosition.current.set(x, 0, z);
+
+    if (groupRef.current) {
+      groupRef.current.position.copy(orbitalPosition.current);
+    }
+
     if (onPositionUpdate) {
       onPositionUpdate(body.id, orbitalPosition.current);
     }
+
     if (meshRef.current) {
-      meshRef.current.rotation.y += body.rotationSpeed;
+      meshRef.current.rotation.y += body.rotationRate * delta;
+    }
+
+    if (orbitRingRef.current) {
+      if (parentCoords) {
+        orbitRingRef.current.position.set(parentCoords[0], parentCoords[1], parentCoords[2]);
+      } else {
+        orbitRingRef.current.position.set(0, 0, 0);
+      }
     }
   });
 
+  const emissiveColor = body.id === 'sun' ? '#f8a04a' : '#090b1a';
+  const emissiveIntensity = body.id === 'sun' ? 1.15 : 0.08;
+
   return (
-    <group ref={groupRef}>
-      {body.orbitRadius > 0 && <OrbitRing radius={body.orbitRadius} />}
-      <mesh
-        ref={meshRef}
-        position={[0, 0, 0]}
-        onClick={(event) => {
-          event.stopPropagation();
-          if (groupRef.current) {
-            onSelect(body, groupRef.current.getWorldPosition(worldPosition.current.clone()));
-          } else {
-            onSelect(body, new THREE.Vector3());
-          }
-        }}
-        onPointerOver={(event) => {
-          event.stopPropagation();
-          document.body.style.cursor = 'pointer';
-        }}
-        onPointerOut={() => {
-          document.body.style.cursor = 'default';
-        }}
-      >
-        <sphereGeometry args={[body.size, 32, 32]} />
-        <meshStandardMaterial color={body.color} emissive={body.id === 'sun' ? '#c96f15' : '#111'} emissiveIntensity={0.2} />
-        {isSelected && (
-          <Html distanceFactor={12} transform position={[0, body.size * 1.4, 0]}>
-            <article className="body-tooltip">
-              <h3>{body.name}</h3>
-              <p>{body.description}</p>
-              <button onClick={() => onExplore(body)}>Explore</button>
-            </article>
-          </Html>
-        )}
-      </mesh>
-    </group>
+    <>
+      {body.semiMajorAxis > 0 && (
+        <OrbitRing
+          ref={orbitRingRef}
+          semiMajor={body.semiMajorAxis}
+          semiMinor={body.semiMinorAxis}
+          inclination={body.inclination}
+        />
+      )}
+      <group ref={groupRef}>
+        <group ref={tiltGroupRef}>
+          <mesh
+            ref={meshRef}
+            position={[0, 0, 0]}
+            onClick={(event) => {
+              event.stopPropagation();
+              if (groupRef.current) {
+                onSelect(body, groupRef.current.getWorldPosition(worldPosition.current.clone()));
+              } else {
+                onSelect(body, new THREE.Vector3());
+              }
+            }}
+            onPointerOver={(event) => {
+              event.stopPropagation();
+              document.body.style.cursor = 'pointer';
+            }}
+            onPointerOut={() => {
+              document.body.style.cursor = 'default';
+            }}
+          >
+            <sphereGeometry args={[body.size, 32, 32]} />
+            <meshStandardMaterial
+              color={body.color}
+              map={hasDiffuseTexture ? diffuseMap : null}
+              normalMap={hasNormalMap ? normalMap : null}
+              emissive={emissiveColor}
+              emissiveMap={hasEmissiveMap ? emissiveMap : null}
+              emissiveIntensity={emissiveIntensity}
+              roughness={0.85}
+              metalness={0.1}
+            />
+            {body.rings && ringTexture && (
+              <mesh rotation={[Math.PI / 2, 0, 0]}>
+                <ringGeometry args={[body.rings.innerRadius, body.rings.outerRadius, 128]} />
+                <meshStandardMaterial
+                  map={ringTexture}
+                  transparent
+                  opacity={0.85}
+                  side={THREE.DoubleSide}
+                  depthWrite={false}
+                />
+              </mesh>
+            )}
+            {isSelected && (
+              <Html distanceFactor={12} transform position={[0, body.size * 1.4, 0]}>
+                <article className="body-tooltip">
+                  <h3>{body.name}</h3>
+                  <p>{body.description}</p>
+                  <button onClick={() => onExplore(body)}>Explore</button>
+                </article>
+              </Html>
+            )}
+          </mesh>
+        </group>
+      </group>
+    </>
   );
 }
 
@@ -114,7 +302,7 @@ export default function SolarSystemPage() {
   const [selectedBodyId, setSelectedBodyId] = useState('earth');
   const [focusPosition, setFocusPosition] = useState(() => {
     const initial = getBodyById('earth');
-    return initial ? [initial.orbitRadius, 0, 0] : [0, 0, 0];
+    return initial ? [initial.semiMajorAxis, 0, 0] : [0, 0, 0];
   });
   const [visitedBodies, setVisitedBodies] = useState(() => getVisitedBodies());
   const { start } = useSpaceAudio();
@@ -136,9 +324,11 @@ export default function SolarSystemPage() {
     if (stored) {
       setFocusPosition([stored[0], stored[1], stored[2]]);
     } else {
-      setFocusPosition([body.orbitRadius, 0, 0]);
+      setFocusPosition([body.semiMajorAxis, 0, 0]);
     }
   }, []);
+
+  const getBodyPosition = useCallback((bodyId) => bodyPositionsRef.current.get(bodyId), []);
 
   const handleMarkVisited = useCallback((bodyId) => {
     const updated = markBodyVisited(bodyId);
@@ -180,7 +370,8 @@ export default function SolarSystemPage() {
           <h1>Solar System Navigator</h1>
           <p>{selectedBody ? `${selectedBody.name} briefing loaded.` : 'Select a body to begin.'}</p>
           <p>
-            Progress: {visitedBodies.size} / {celestialBodies.length} bodies ({Number.isFinite(progressPercentage) ? progressPercentage : 0}% tracked)
+            Progress: {visitedBodies.size} / {celestialBodies.length} bodies (
+            {Number.isFinite(progressPercentage) ? progressPercentage : 0}% tracked)
           </p>
         </div>
         <button onClick={() => navigate('/workbench')} className="secondary">
@@ -192,8 +383,9 @@ export default function SolarSystemPage() {
           <Suspense fallback={<div className="solar-loading">Preparing star charts…</div>}>
             <Canvas camera={{ position: [0, 12, 55], fov: 50 }} shadows>
               <color attach="background" args={[0x02030f]} />
-              <ambientLight intensity={0.2} />
-              <pointLight position={[0, 0, 0]} intensity={2.5} color="#ffdca8" />
+              <ambientLight intensity={0.28} color="#1a2134" />
+              <hemisphereLight skyColor="#45648f" groundColor="#05060d" intensity={0.35} />
+              <pointLight position={[0, 0, 0]} intensity={3} distance={280} decay={2} color="#ffd39c" castShadow />
               <Stars radius={120} depth={40} count={3000} factor={6} saturation={0} fade speed={0.5} />
               {celestialBodies.map((body) => (
                 <CelestialBody
@@ -203,6 +395,7 @@ export default function SolarSystemPage() {
                   onSelect={handleSelect}
                   onExplore={handleExplore}
                   onPositionUpdate={handlePositionUpdate}
+                  getBodyPosition={getBodyPosition}
                 />
               ))}
               <CameraRig focusPosition={focusPosition} />

--- a/frontend/src/utils/textureRegistry.js
+++ b/frontend/src/utils/textureRegistry.js
@@ -1,0 +1,31 @@
+const textureModules = import.meta.glob('../assets/textures/**/*.{jpg,jpeg,png,webp,avif}', {
+  eager: true,
+  import: 'default'
+});
+
+const textureLookup = Object.entries(textureModules).reduce((acc, [path, module]) => {
+  if (!module) {
+    return acc;
+  }
+  const segments = path.split('/');
+  const fileName = segments[segments.length - 1];
+  const baseName = fileName.replace(/\.[^.]+$/, '');
+  acc[fileName] = module;
+  acc[baseName] = module;
+  return acc;
+}, {});
+
+export function resolveTextureSource(key) {
+  if (!key) {
+    return null;
+  }
+  return textureLookup[key] ?? null;
+}
+
+export function buildTextureSet({ textureKey, normalMapKey, emissiveMapKey } = {}) {
+  return {
+    map: resolveTextureSource(textureKey),
+    normalMap: resolveTextureSource(normalMapKey),
+    emissiveMap: resolveTextureSource(emissiveMapKey)
+  };
+}

--- a/frontend/src/utils/textureRegistry.js
+++ b/frontend/src/utils/textureRegistry.js
@@ -3,23 +3,43 @@ const textureModules = import.meta.glob('../assets/textures/**/*.{jpg,jpeg,png,w
   import: 'default'
 });
 
+function registerLookupEntry(registry, key, module) {
+  if (!key || !module) {
+    return;
+  }
+  const trimmed = key.trim();
+  if (!trimmed) {
+    return;
+  }
+  registry[trimmed] = module;
+  registry[trimmed.toLowerCase()] = module;
+}
+
 const textureLookup = Object.entries(textureModules).reduce((acc, [path, module]) => {
   if (!module) {
     return acc;
   }
   const segments = path.split('/');
-  const fileName = segments[segments.length - 1];
+  const fileName = segments[segments.length - 1] ?? '';
   const baseName = fileName.replace(/\.[^.]+$/, '');
-  acc[fileName] = module;
-  acc[baseName] = module;
+  registerLookupEntry(acc, fileName, module);
+  registerLookupEntry(acc, baseName, module);
   return acc;
 }, {});
 
+function normalizeKey(key) {
+  if (typeof key !== 'string') {
+    return '';
+  }
+  return key.trim();
+}
+
 export function resolveTextureSource(key) {
-  if (!key) {
+  const normalized = normalizeKey(key);
+  if (!normalized) {
     return null;
   }
-  return textureLookup[key] ?? null;
+  return textureLookup[normalized] ?? textureLookup[normalized.toLowerCase()] ?? null;
 }
 
 export function buildTextureSet({ textureKey, normalMapKey, emissiveMapKey } = {}) {


### PR DESCRIPTION
## Summary
- ignore committed binary planet textures and keep an empty placeholder directory for locally supplied assets
- update celestial body metadata to reference texture keys instead of bundling image imports
- add a texture registry and renderer fallback logic so materials resolve user-provided files at runtime without bundling binaries

## Testing
- npm run build --prefix frontend

------
https://chatgpt.com/codex/tasks/task_b_68d810103888832e8ecb41d586cad8fa